### PR TITLE
Refresh framebuffer

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -11,8 +11,8 @@ pub struct Buffer<'a> {
 impl<'a> Buffer<'a> {
     pub fn new(buf: &'a mut MmapMut, dimensions: (u32, u32)) -> Buffer {
         Buffer {
-            buf: buf,
-            dimensions: dimensions,
+            buf,
+            dimensions,
             subdimensions: None,
         }
     }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -6,9 +6,8 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 use rusttype::{point, Font as RustFont, Scale};
 
-pub static DEJAVUSANS_MONO_FONT_DATA: &'static [u8] =
-    include_bytes!("../fonts/dejavu/DejaVuSansMono.ttf");
-pub static ROBOTO_REGULAR_FONT_DATA: &'static [u8] = include_bytes!("../fonts/Roboto-Regular.ttf");
+pub static DEJAVUSANS_MONO_FONT_DATA: &[u8] = include_bytes!("../fonts/dejavu/DejaVuSansMono.ttf");
+pub static ROBOTO_REGULAR_FONT_DATA: &[u8] = include_bytes!("../fonts/Roboto-Regular.ttf");
 
 lazy_static! {
     pub static ref DEJAVUSANS_MONO: RustFont<'static> =
@@ -47,9 +46,9 @@ impl CachedGlyph {
                 render[pos as usize] = o;
             });
             CachedGlyph {
-                origin: origin,
-                dimensions: dimensions,
-                render: render,
+                origin,
+                dimensions,
+                render,
             }
         } else {
             CachedGlyph {
@@ -69,7 +68,7 @@ impl CachedGlyph {
                     (x + pos.0 + self.origin.0) as u32,
                     (y + pos.1 + self.origin.1) as u32,
                 ),
-                &bg.blend(&c, *v),
+                &bg.blend(c, *v),
             );
 
             if x == self.dimensions.0 as i32 - 1 {
@@ -92,8 +91,8 @@ impl Font {
     pub fn new(font: &'static RustFont, size: f32) -> Font {
         Font {
             glyphs: HashMap::new(),
-            font: font,
-            size: size,
+            font,
+            size,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ extern crate osstrtools;
 
 use std::io::Read;
 
-
 use framebuffer::{Framebuffer, KdMode};
 use structopt::StructOpt;
 use termion::raw::IntoRawMode;
@@ -19,9 +18,7 @@ mod color;
 mod draw;
 mod greetd;
 
-
-#[derive(StructOpt)]
-#[derive(Debug)]
+#[derive(StructOpt, Debug)]
 struct Opts {
     // The path to the file to read
     #[structopt(short, long, parse(from_os_str))]
@@ -43,7 +40,7 @@ struct LoginManager<'a> {
     dimensions: (u32, u32),
     mode: Mode,
     greetd: greetd::GreetD,
-    target: String
+    target: String,
 }
 
 impl<'a> LoginManager<'a> {
@@ -52,7 +49,7 @@ impl<'a> LoginManager<'a> {
         screen_size: (u32, u32),
         dimensions: (u32, u32),
         greetd: greetd::GreetD,
-        target: std::path::PathBuf
+        target: std::path::PathBuf,
     ) -> LoginManager {
         LoginManager {
             buf: buf,
@@ -62,7 +59,7 @@ impl<'a> LoginManager<'a> {
             dimensions,
             mode: Mode::EditingUsername,
             greetd: greetd,
-            target:target.into_os_string().into_string().unwrap(),
+            target: target.into_os_string().into_string().unwrap(),
         }
     }
 
@@ -219,7 +216,7 @@ impl<'a> LoginManager<'a> {
                     username.truncate(0);
                     password.truncate(0);
                     self.greetd.cancel();
-                    return
+                    return;
                 }
                 '\x7F' => match self.mode {
                     // backspace
@@ -255,11 +252,9 @@ impl<'a> LoginManager<'a> {
                         } else {
                             self.draw_bg(&color::Color::new(0.75, 0.75, 0.25, 1.0))
                                 .expect("unable to draw background");
-                            let res = self.greetd.login(
-                                username,
-                                password,
-                                vec![self.target.clone()],
-                            );
+                            let res =
+                                self.greetd
+                                    .login(username, password, vec![self.target.clone()]);
                             username = String::with_capacity(USERNAME_CAP);
                             password = String::with_capacity(PASSWORD_CAP);
                             match res {
@@ -301,7 +296,13 @@ fn main() {
     let greetd = greetd::GreetD::new();
     let args = Opts::from_args();
 
-    let mut lm = LoginManager::new(&mut framebuffer.frame, (w, h), (1024, 128), greetd, args.target);
+    let mut lm = LoginManager::new(
+        &mut framebuffer.frame,
+        (w, h),
+        (1024, 128),
+        greetd,
+        args.target,
+    );
 
     lm.clear();
     lm.draw_bg(&color::Color::new(0.75, 0.75, 0.75, 1.0))

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,8 +194,8 @@ impl<'a> LoginManager<'a> {
             if stdin.read_exact(&mut b).is_err() {
                 let _ =
                     Framebuffer::set_kd_mode(KdMode::Text).expect("unable to leave graphics mode");
-                username.truncate(0);
-                password.truncate(0);
+                username.clear();
+                password.clear();
                 std::process::exit(1);
             }
 
@@ -208,13 +208,13 @@ impl<'a> LoginManager<'a> {
             match b[0] as char {
                 '\x15' | '\x0B' => match self.mode {
                     // ctrl-k/ctrl-u
-                    Mode::EditingUsername => username.truncate(0),
-                    Mode::EditingPassword => password.truncate(0),
+                    Mode::EditingUsername => username.clear(),
+                    Mode::EditingPassword => password.clear(),
                 },
                 '\x03' | '\x04' => {
                     // ctrl-c/ctrl-D
-                    username.truncate(0);
-                    password.truncate(0);
+                    username.clear();
+                    password.clear();
                     self.greetd.cancel();
                     return;
                 }
@@ -243,7 +243,7 @@ impl<'a> LoginManager<'a> {
                     }
                     Mode::EditingPassword => {
                         if password.is_empty() {
-                            username.truncate(0);
+                            username.clear();
                             self.mode = Mode::EditingUsername;
                         } else {
                             self.draw_bg(&color::Color::new(0.75, 0.75, 0.25, 1.0))


### PR DESCRIPTION
I don't know how specific this is to my machine, but without refreshing, the display would only update upon *exiting* graphics mode.
Not doing so rendered ddlm basically unusable, but I managed to figure out what was going wrong, and with this change, I can actually use ddlm now.
